### PR TITLE
Move Makefile lint command to npm script.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,4 @@ deps:
 # Lint CoffeeScript
 lint:
 	@echo "Linting CoffeeScript..."
-	@./node_modules/.bin/coffeelint \
-		-f ./test/coffeelint.json \
-    ./scripts/helpers/* \
-		./scripts/*
+	@npm run lint

--- a/package.json
+++ b/package.json
@@ -31,5 +31,8 @@
     },
     "engines": {
         "node": "0.10.x"
+    },
+    "scripts": {
+        "lint": "coffeelint -f ./test/coffeelint.json ./scripts/helpers/* ./scripts/*"
     }
 }


### PR DESCRIPTION
Now linting can be achieved via `npm run lint` and we still maintain backwards compatibility in the Makefile. (Note npm automatically expands commands to run from `./node_modules/.bin` where possible, so including this is unnecessary.)

PS: check your email :wink: 